### PR TITLE
increase default year filter to 2025

### DIFF
--- a/config/install/field.field.node.localgov_planning_notices_list.localgov_pnl_year.yml
+++ b/config/install/field.field.node.localgov_planning_notices_list.localgov_pnl_year.yml
@@ -16,7 +16,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: '2024'
+    value: '2025'
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/install/views.view.planning_notices.yml
+++ b/config/install/views.view.planning_notices.yml
@@ -304,7 +304,7 @@ display:
           plugin_id: list_field
           operator: or
           value:
-            2023: '2023'
+            2025: '2025'
           group: 1
           exposed: true
           expose:


### PR DESCRIPTION
Closes #1

## What does this change?
The default year for listing planning notices is currently 2023. This increases that to 2025.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.